### PR TITLE
client: add DoCtx for fasthttp.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -426,7 +426,7 @@ func (c *Client) mCleaner(m map[string]*HostClient) {
 		t := time.Now()
 		c.mLock.Lock()
 		for k, v := range m {
-			if t.Sub(v.LastUseTime()) > time.Minute {
+			if t.Sub(v.LastUseTime()) > c.MaxIdleConnDuration {
 				delete(m, k)
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -422,11 +422,15 @@ func (c *Client) Do(req *Request, resp *Response) error {
 
 func (c *Client) mCleaner(m map[string]*HostClient) {
 	mustStop := false
+	unusedTimeout := c.MaxIdleConnDuration
+	if unusedTimeout <= 0 {
+		unusedTimeout = time.Minute
+	}
 	for {
 		t := time.Now()
 		c.mLock.Lock()
 		for k, v := range m {
-			if t.Sub(v.LastUseTime()) > c.MaxIdleConnDuration {
+			if t.Sub(v.LastUseTime()) > unusedTimeout {
 				delete(m, k)
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -266,6 +266,28 @@ func (c *Client) Post(dst []byte, url string, postArgs *Args) (statusCode int, b
 	return clientPostURL(dst, url, postArgs, c)
 }
 
+// DoCtx performs the given request and waits for response until
+// the given context is cancelled or deadline is reached.
+//
+// Request must contain at least non-zero RequestURI with full url (including
+// scheme and host) or non-zero Host header + RequestURI.
+//
+// The function doesn't follow redirects. Use Get* for following redirects.
+//
+// Response is ignored if resp is nil.
+//
+// ErrTimeout is returned if the response wasn't returned until
+// the deadline provided by the given context.
+//
+// ErrNoFreeConns is returned if all HostClient.MaxConns connections
+// to the host are busy.
+//
+// It is recommended obtaining req and resp via AcquireRequest
+// and AcquireResponse in performance-critical code.
+func (c *Client) DoCtx(ctx context.Context, req *Request, resp *Response) error {
+	return clientDoCtx(ctx, req, resp, c)
+}
+
 // DoTimeout performs the given request and waits for response during
 // the given timeout duration.
 //


### PR DESCRIPTION
- Add DoCtx to make it consistent with fasthttp.HostClient.
- Change default expiration of HostClient map to use MaxIdleConnDuration instead of hardcoded value of 1m. This will allow to get more control on clients eviction, for example for https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4931